### PR TITLE
Choose monitor size to use and manually override that size if needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,109 @@
+__pycache__
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+.Python build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+*.manifest
+*.spec
+
+# Log files
+pip-log.txt
+pip-delete-this-directory.txt
+*.log
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+.pytest_cache/
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pyflow
+__pypackages__/
+
+# Environment
+.env
+.venv
+env/
+venv/
+ENV/
+
+# If you are using PyCharm #
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/dictionaries
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/gradle.xml
+.idea/**/libraries
+*.iws /out/
+
+# Sublime Text
+*.tmlanguage.cache
+*.tmPreferences.cache
+*.stTheme.cache
+*.sublime-workspace
+*.sublime-project
+
+# sftp configuration file
+sftp-config.json
+
+# Package control specific files Package
+Control.last-run
+Control.ca-list
+Control.ca-bundle
+Control.system-ca-bundle
+GitHub.sublime-settings
+
+# Visual Studio Code #
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+.history
+
+# JetBrains
+.idea

--- a/zoom_and_follow_mouse.py
+++ b/zoom_and_follow_mouse.py
@@ -9,6 +9,9 @@ hotkey_id_tog = None
 HOTKEY_NAME_TOG = "zoom_follow.toggle"
 HOTKEY_DESC_TOG = "Enable/Disable Mouse Zoom and Follow"
 USE_MANUAL_MONITOR_SIZE = "Manual Monitor Size"
+lock_zoom_id_tog = None
+LOCK_ZOOM_NAME_TOG = "zoom_lock.toggle"
+LOCK_ZOOM_DESC_TOG = "Enable/Disable Lock Zoom"
 
 # -------------------------------------------------------------------
 
@@ -194,11 +197,12 @@ class CursorWindow:
         self.set_crop(0)
 
     def tracking(self):
-        if self.lock:
-            self.follow(get_position())
-            self.set_crop(1)
-        else:
-            self.reset_crop()
+        if self.track:
+            if self.lock:
+                self.follow(get_position())
+                self.set_crop(1)
+            else:
+                self.reset_crop()
 
     def tick(self):
         # Containing function that is run every frame
@@ -296,15 +300,27 @@ def script_load(settings):
     obs.obs_hotkey_load(hotkey_id_tog, hotkey_save_array)
     obs.obs_data_array_release(hotkey_save_array)
 
+    global lock_zoom_id_tog
+    lock_zoom_id_tog = obs.obs_hotkey_register_frontend(
+        LOCK_ZOOM_NAME_TOG, LOCK_ZOOM_DESC_TOG, toggle_zoom_lock
+    )
+    lock_zoom_save_array = obs.obs_data_get_array(settings, LOCK_ZOOM_NAME_TOG)
+    obs.obs_hotkey_load(lock_zoom_id_tog, lock_zoom_save_array)
+    obs.obs_data_array_release(lock_zoom_save_array)
+
 
 def script_unload():
     obs.obs_hotkey_unregister(toggle_zoom_follow)
+    obs.obs_hotkey_unregister(toggle_zoom_lock)
 
 
 def script_save(settings):
     hotkey_save_array = obs.obs_hotkey_save(hotkey_id_tog)
     obs.obs_data_set_array(settings, HOTKEY_NAME_TOG, hotkey_save_array)
     obs.obs_data_array_release(hotkey_save_array)
+    lock_zoom_save_array = obs.obs_hotkey_save(lock_zoom_id_tog)
+    obs.obs_data_set_array(settings, LOCK_ZOOM_NAME_TOG, lock_zoom_save_array)
+    obs.obs_data_array_release(lock_zoom_save_array)
 
 
 def toggle_zoom_follow(pressed):
@@ -317,3 +333,9 @@ def toggle_zoom_follow(pressed):
         elif not zoom.flag:
             zoom.flag = True
             zoom.lock = False
+
+
+def toggle_zoom_lock(pressed):
+    if pressed:
+        print("Toggling zoom track")
+        zoom.track = not zoom.track

--- a/zoom_and_follow_mouse.py
+++ b/zoom_and_follow_mouse.py
@@ -9,9 +9,6 @@ hotkey_id_tog = None
 HOTKEY_NAME_TOG = "zoom_follow.toggle"
 HOTKEY_DESC_TOG = "Enable/Disable Mouse Zoom and Follow"
 USE_MANUAL_MONITOR_SIZE = "Manual Monitor Size"
-lock_zoom_id_tog = None
-LOCK_ZOOM_NAME_TOG = "zoom_lock.toggle"
-LOCK_ZOOM_DESC_TOG = "Enable/Disable Lock Zoom"
 
 # -------------------------------------------------------------------
 
@@ -197,12 +194,11 @@ class CursorWindow:
         self.set_crop(0)
 
     def tracking(self):
-        if self.track:
-            if self.lock:
-                self.follow(get_position())
-                self.set_crop(1)
-            else:
-                self.reset_crop()
+        if self.lock:
+            self.follow(get_position())
+            self.set_crop(1)
+        else:
+            self.reset_crop()
 
     def tick(self):
         # Containing function that is run every frame
@@ -300,27 +296,15 @@ def script_load(settings):
     obs.obs_hotkey_load(hotkey_id_tog, hotkey_save_array)
     obs.obs_data_array_release(hotkey_save_array)
 
-    global lock_zoom_id_tog
-    lock_zoom_id_tog = obs.obs_hotkey_register_frontend(
-        LOCK_ZOOM_NAME_TOG, LOCK_ZOOM_DESC_TOG, toggle_zoom_lock
-    )
-    lock_zoom_save_array = obs.obs_data_get_array(settings, LOCK_ZOOM_NAME_TOG)
-    obs.obs_hotkey_load(lock_zoom_id_tog, lock_zoom_save_array)
-    obs.obs_data_array_release(lock_zoom_save_array)
-
 
 def script_unload():
     obs.obs_hotkey_unregister(toggle_zoom_follow)
-    obs.obs_hotkey_unregister(toggle_zoom_lock)
 
 
 def script_save(settings):
     hotkey_save_array = obs.obs_hotkey_save(hotkey_id_tog)
     obs.obs_data_set_array(settings, HOTKEY_NAME_TOG, hotkey_save_array)
     obs.obs_data_array_release(hotkey_save_array)
-    lock_zoom_save_array = obs.obs_hotkey_save(lock_zoom_id_tog)
-    obs.obs_data_set_array(settings, LOCK_ZOOM_NAME_TOG, lock_zoom_save_array)
-    obs.obs_data_array_release(lock_zoom_save_array)
 
 
 def toggle_zoom_follow(pressed):
@@ -333,9 +317,3 @@ def toggle_zoom_follow(pressed):
         elif not zoom.flag:
             zoom.flag = True
             zoom.lock = False
-
-
-def toggle_zoom_lock(pressed):
-    if pressed:
-        print("Toggling zoom track")
-        zoom.track = not zoom.track

--- a/zoom_and_follow_mouse.py
+++ b/zoom_and_follow_mouse.py
@@ -8,6 +8,7 @@ get_position = lambda: c.position
 hotkey_id_tog = None
 HOTKEY_NAME_TOG = "zoom_follow.toggle"
 HOTKEY_DESC_TOG = "Enable/Disable Mouse Zoom and Follow"
+USE_MANUAL_MONITOR_SIZE = "Manual Monitor Size"
 
 # -------------------------------------------------------------------
 
@@ -21,6 +22,8 @@ class CursorWindow:
     monitor_idx = 0
     d_w = get_monitors()[monitor_idx].width
     d_h = get_monitors()[monitor_idx].height
+    d_w_override = get_monitors()[monitor_idx].width
+    d_h_override = get_monitors()[monitor_idx].height
     z_x = 0
     z_y = 0
     refresh_rate = 16
@@ -38,11 +41,16 @@ class CursorWindow:
             monitor = get_monitors()[self.monitor_idx]
             self.d_w = monitor.width
             self.d_h = monitor.height
+        else:
+            self.d_w = self.d_w_override
+            self.d_h = self.d_h_override
 
     def switch_to_monitor(self, monitor_name):
         for i, monitor in enumerate(get_monitors()):
             if monitor_name == monitor.name:
                 self.monitor_idx = i
+                return
+        self.monitor_idx = len(get_monitors()) + 1000
 
     def resetZI(self):
         self.zi_timer = 0
@@ -220,6 +228,8 @@ def script_defaults(settings):
     obs.obs_data_set_default_double(settings, "Smooth", zoom.smooth)
     obs.obs_data_set_default_int(settings, "Zoom", int(zoom.zoom_d))
     obs.obs_data_set_default_string(settings, "Monitor", get_monitors()[0].name)
+    obs.obs_data_set_default_int(settings, "Manual Monitor Width", get_monitors()[0].width)
+    obs.obs_data_set_default_int(settings, "Manual Monitor Height", get_monitors()[0].height)
 
 
 def script_update(settings):
@@ -232,6 +242,8 @@ def script_update(settings):
     zoom.smooth = obs.obs_data_get_double(settings, "Smooth")
     zoom.zoom_d = obs.obs_data_get_double(settings, "Zoom")
     zoom.switch_to_monitor(obs.obs_data_get_string(settings, "Monitor"))
+    zoom.d_w_override = obs.obs_data_get_int(settings, "Manual Monitor Width")
+    zoom.d_h_override = obs.obs_data_get_int(settings, "Manual Monitor Height")
 
 
 def script_properties():
@@ -261,6 +273,10 @@ def script_properties():
     )
     for monitor in get_monitors():
         obs.obs_property_list_add_string(monitors_prop_list, monitor.name, monitor.name)
+    obs.obs_property_list_add_string(monitors_prop_list, USE_MANUAL_MONITOR_SIZE, USE_MANUAL_MONITOR_SIZE)
+    obs.obs_properties_add_int(props, "Manual Monitor Width", "Manual Monitor Width", 320, 3840, 1)
+    obs.obs_properties_add_int(props, "Manual Monitor Height", "Manual Monitor Height", 240, 3840, 1)
+
     obs.obs_properties_add_int(props, "Width", "Zoom Window Width", 320, 3840, 1)
     obs.obs_properties_add_int(props, "Height", "Zoom Window Height", 240, 3840, 1)
     obs.obs_properties_add_float_slider(props, "Border", "Active Border", 0, 0.33, 0.01)


### PR DESCRIPTION
If a window wasn't fullscreen or is not on the default monitor the zoom can add black bars to the sides and hide the content you're trying to focus in. This pull does two things:

 - Specify which window the source is on. This handles this problem when your source is on a different monitor from the default and the size is different.
 - Manually specify the width and height of the monitor. This treats any size window as if it were the full size of the monitor.