### PR TITLE
improved macos support

### DIFF
--- a/zoom_and_follow_mouse.py
+++ b/zoom_and_follow_mouse.py
@@ -1,5 +1,5 @@
 import obspython as obs 
-import pywinctl as pwc # version >=0.0.30
+import pywinctl as pwc # version >=0.0.38
 from math import sqrt
 from json import loads
 

--- a/zoom_and_follow_mouse.py
+++ b/zoom_and_follow_mouse.py
@@ -96,14 +96,12 @@ class CursorWindow:
                         self.update_monitor_dim(monitor)
         elif (self.source_type == 'display_capture'):
             # the 'display' property is an index value and not the true monitor id. 
+            # it is only returned when there is more than one monitor on your system.
             # we will assume that the order of the monitors returned from pywinctl 
             # are  in the same order that OBS is assigning the display index value.
-            if 'display' in data:
-                monitor_index = data.get('display')
-                if (monitor_index < len(self.monitors)):
-                    self.update_monitor_dim(self.monitors[self.monitors_key[monitor_index]])
-            else:
-                print(f"Key 'display' does not exist in {data}")
+            monitor_index = data.get('display', 0)
+            if (monitor_index < len(self.monitors)):
+                self.update_monitor_dim(self.monitors[self.monitors_key[monitor_index]])
         if (self.s_x_override > 0):
             self.s_x += self.s_x_override
         if (self.s_y_override > 0):

--- a/zoom_and_follow_mouse.py
+++ b/zoom_and_follow_mouse.py
@@ -69,18 +69,18 @@ class CursorWindow:
 
 
     def update_source_size(self):
-        data = obs.obs_data_get_json(obs.obs_source_get_settings(obs.obs_get_source_by_name(self.source_name)))
+        data = loads(obs.obs_data_get_json(obs.obs_source_get_settings(obs.obs_get_source_by_name(self.source_name))))
         self.source_type = obs.obs_source_get_id(obs.obs_get_source_by_name(self.source_name))
         if (self.source_type == 'window_capture') or (self.source_type == 'game_capture'):
-            data = loads(data)['window'].split(":")
+            data = data['window'].split(":")
             self.window = pwc.getWindowsWithTitle(self.windows[data[2]][0])[0]
             self.update_window_dim()
         elif (self.source_type == 'monitor_capture'): 
             try:
-                data = loads(data)['monitor']
+                data = data['monitor']
             except:
                 print("Key 'monitor' does not exist in data")
-                print(loads(data))
+                print(data)
             else:
                 for i in range(len(self.monitors_key)):
                     monitor = self.monitors[self.monitors_key[i]]

--- a/zoom_and_follow_mouse.py
+++ b/zoom_and_follow_mouse.py
@@ -60,8 +60,7 @@ class CursorWindow:
                 self.s_x = window_dim.left
                 self.s_y = window_dim.top
 
-    def update_monitor_dim(self, monitor, id):
-        if (monitor['id'] == id):
+    def update_monitor_dim(self, monitor):
             self.d_w = monitor['size'].width
             self.d_h = monitor['size'].height
             self.s_x = monitor['pos'].x
@@ -75,16 +74,14 @@ class CursorWindow:
             data = data['window'].split(":")
             self.window = pwc.getWindowsWithTitle(self.windows[data[2]][0])[0]
             self.update_window_dim()
-        elif (self.source_type == 'monitor_capture'): 
-            try:
-                data = data['monitor']
-            except:
-                print("Key 'monitor' does not exist in data")
-                print(data)
+        elif (self.source_type == 'monitor_capture'):
+            monitor_id = data.get('monitor', None)
+            if monitor_id == None:
+                print(f"Key 'monitor' does not exist in {data}")
             else:
-                for i in range(len(self.monitors_key)):
-                    monitor = self.monitors[self.monitors_key[i]]
-                    self.update_monitor_dim(monitor, data)
+                for monitor in self.monitors.items():
+                    if (monitor['id'] == monitor_id):
+                        self.update_monitor_dim(monitor)
         if (self.s_x_override > 0):
             self.s_x += self.s_x_override
         if (self.s_y_override > 0):

--- a/zoom_and_follow_mouse.py
+++ b/zoom_and_follow_mouse.py
@@ -98,11 +98,12 @@ class CursorWindow:
             # the 'display' property is an index value and not the true monitor id. 
             # we will assume that the order of the monitors returned from pywinctl 
             # are  in the same order that OBS is assigning the display index value.
-            monitor_index = data.get('display', None)
-            if monitor_index == None:
+            if 'display' in data:
+                monitor_index = data.get('display')
+                if (monitor_index < len(self.monitors)):
+                    self.update_monitor_dim(self.monitors[self.monitors_key[monitor_index]])
+            else:
                 print(f"Key 'display' does not exist in {data}")
-            elif (monitor_index < len(self.monitors)):
-                self.update_monitor_dim(self.monitors[self.monitors_key[monitor_index]])
         if (self.s_x_override > 0):
             self.s_x += self.s_x_override
         if (self.s_y_override > 0):


### PR DESCRIPTION
Hi, this is my first time doing anything with OBS and plugins so please be kind to any offensive code 🙂

I wanted to use this plugin but ran into some struggles getting it to work on macOS. I am using OBS 27.2.4 (I don't know what version of OBS this plugin is intended to work with). I preserved the original script behavior in my modifications to the best of my abilities. I do not have a Windows PC to test on however.

Changes:
- Added partial support for zoom and mouse follow for 'Display Capture' sources used on macOS

	It seems Windows/Linux call the OBS source 'Monitor Capture' but on macOS it is called 'Display Capture'. One caveat to the macOS version is that it returns the selected monitor/display as an indexed number and instead of its underlying 'id'. So I have to make an assumption that the order of monitors that pywinctl returns is in the same order that OBS uses.

- Partially fixed 'Window Capture' sources on macOS but it remains broken unfortunately

	I am making an assumption that on Windows the properties returned from the window_capture source differs than on macOS. On macOS when I get the properties there is an 'owner_name', 'window', 'window_name' property. The 'owner_name' property is the Application name, the 'window_name' property is the window title and the 'window' property is the window id. It seems on Windows the 'window' property includes all of those things which is why you split by ':' (?). Assuming 'window_name' is not a property returned on Windows, I believe my solution here should work since it will attempt to use 'window_name' and if it is not defined it will fallback to 'window'.

	Unfortunately, using window capture on macOS results in an error coming from pywinctl after getting the window information. `NSInternalInconsistencyException - NSWindow drag regions should only be invalidated on the Main Thread!` I am not sure how to resolve this issue, this may be a limitation with how OBS plugins are run?

- Requires a newer version of pywinctl. From 0.0.30 to 0.0.38. This includes a few fixes to macos issues.


Example:
![Screen Recording 2022-04-02 at 5 52 32 PM](https://user-images.githubusercontent.com/5579960/161402509-0b167180-799b-4856-a1b3-84f55df0224a.gif)

