### PR TITLE
Add support for capturing Pipewire sources on Wayland platforms.

### DIFF
--- a/zoom_and_follow_mouse.py
+++ b/zoom_and_follow_mouse.py
@@ -36,13 +36,6 @@ ZOOM_DESC_TOG = "Enable/Disable Mouse Zoom"
 FOLLOW_DESC_TOG = "Enable/Disable Mouse Follow"
 USE_MANUAL_MONITOR_SIZE = "Manual Monitor Size"
 
-WIN = "windows"
-MAC = "macos"
-LIN_OTH = "linux/other"
-
-WINDOW = 'window source'
-MONITOR = 'monitor source'
-
 
 # -------------------------------------------------------------------
 class WindowCaptureSources:


### PR DESCRIPTION
I refactored the capture source checking logic a little bit in the hope of making future additions easier; the current options assume _window_ capture sources are the same across all OSs and only _monitor_ captures differ.

I'm still in the process of verifying this works on my system, but wanted to share it as I've seen a few other [issues](https://github.com/tryptech/obs-zoom-and-follow/issues) that might be solved with this change.

VSCode autopep8 default formatting has been applied; some of them I agree with, other's I could take or leave. Let me know if anything is particularly ugly now.