### PR TITLE
Many fixes and QoL improvements

### DIFF
--- a/zoom_and_follow_mouse.py
+++ b/zoom_and_follow_mouse.py
@@ -76,11 +76,11 @@ SOURCES = CaptureSources(
 
 
 class CursorWindow:
-    # Activate zoom mode?
-    lock = False
-    track = update = True
-    ticking = False
-    zi_timer = zo_timer = 0
+    lock = False  # Activate zoom mode?
+    track = True  # Follow mouse cursor while in zoom mode?
+    update = True  # Animating between zoom in and out?
+    ticking = False  # To prevent subscribing to timer multiple times
+    zi_timer = zo_timer = 0  # Frames spent on zoom in/out animations
     windows = window_titles = monitor = window = window_handle \
         = window_name = ''
     monitors = pwc.getAllScreens()
@@ -573,8 +573,8 @@ class CursorWindow:
         obs.obs_source_release(source)
         obs.obs_source_release(crop)
 
-        # Stop ticking when we completed the zoom out or when we're zoomed in
-        # and not following the cursor
+        # Stop ticking when zoom out is complete or
+        # when zoomed in and not following the cursor
         if ((not self.lock) and (self.zo_timer >= totalFrames)) \
                 or (self.lock and (not self.track) and (self.zi_timer >= totalFrames)):
             self.tick_disable()
@@ -584,7 +584,6 @@ class CursorWindow:
             return
 
         obs.timer_add(self.tick, self.refresh_rate)
-
         self.ticking = True
         print(f"Ticking: {self.ticking}")
 

--- a/zoom_and_follow_mouse.py
+++ b/zoom_and_follow_mouse.py
@@ -516,69 +516,69 @@ class CursorWindow:
         crop = obs.obs_source_get_filter_by_name(source, "ZoomCrop")
 
         if crop is None:  # create filter
-            _s = obs.obs_data_create()
-            obs.obs_data_set_bool(_s, "relative", False)
-            f = obs.obs_source_create_private("crop_filter",
-                                              "ZoomCrop", _s)
-            obs.obs_source_filter_add(source, f)
-            obs.obs_source_release(f)
-            obs.obs_data_release(_s)
+            obs_data = obs.obs_data_create()
+            obs.obs_data_set_bool(obs_data, "relative", False)
+            obs_crop_filter = obs.obs_source_create_private("crop_filter",
+                                              "ZoomCrop", obs_data)
+            obs.obs_source_filter_add(source, obs_crop_filter)
+            obs.obs_source_release(obs_crop_filter)
+            obs.obs_data_release(obs_data)
 
-        s = obs.obs_source_get_settings(crop)
-        i = obs.obs_data_set_int
+        crop_settings = obs.obs_source_get_settings(crop)
+        obs_set_int = obs.obs_data_set_int
 
         if inOut == 0:
             self.resetZI()
             if self.zo_timer < totalFrames:
                 self.zo_timer += 1
                 time = self.cubic_in_out(self.zo_timer / totalFrames)
-                i(s, "left", int(((1 - time) * self.zoom_x)))
-                i(s, "top", int(((1 - time) * self.zoom_y)))
-                i(
-                    s,
+                obs_set_int(crop_settings, "left", int(((1 - time) * self.zoom_x)))
+                obs_set_int(crop_settings, "top", int(((1 - time) * self.zoom_y)))
+                obs_set_int(
+                    crop_settings,
                     "cx",
                     self.zoom_w + int(time * (self.source_w - self.zoom_w)),
                 )
-                i(
-                    s,
+                obs_set_int(
+                    crop_settings,
                     "cy",
                     self.zoom_h + int(time * (self.source_h - self.zoom_h)),
                 )
                 self.update = True
             else:
-                i(s, "left", 0)
-                i(s, "top", 0)
-                i(s, "cx", self.source_w)
-                i(s, "cy", self.source_h)
+                obs_set_int(crop_settings, "left", 0)
+                obs_set_int(crop_settings, "top", 0)
+                obs_set_int(crop_settings, "cx", self.source_w)
+                obs_set_int(crop_settings, "cy", self.source_h)
                 self.update = False
         else:
             self.resetZO()
             if self.zi_timer < totalFrames:
                 self.zi_timer += 1
                 time = self.cubic_in_out(self.zi_timer / totalFrames)
-                i(s, "left", int(time * self.zoom_x))
-                i(s, "top", int(time * self.zoom_y))
-                i(
-                    s,
+                obs_set_int(crop_settings, "left", int(time * self.zoom_x))
+                obs_set_int(crop_settings, "top", int(time * self.zoom_y))
+                obs_set_int(
+                    crop_settings,
                     "cx",
                     self.source_w - int(time * (self.source_w - self.zoom_w)),
                 )
-                i(
-                    s,
+                obs_set_int(
+                    crop_settings,
                     "cy",
                     self.source_h - int(time * (self.source_h - self.zoom_h)),
                 )
                 self.update = True if time < 0.8 else False
             else:
-                i(s, "left", int(self.zoom_x))
-                i(s, "top", int(self.zoom_y))
-                i(s, "cx", int(self.zoom_w))
-                i(s, "cy", int(self.zoom_h))
+                obs_set_int(crop_settings, "left", int(self.zoom_x))
+                obs_set_int(crop_settings, "top", int(self.zoom_y))
+                obs_set_int(crop_settings, "cx", int(self.zoom_w))
+                obs_set_int(crop_settings, "cy", int(self.zoom_h))
                 self.update = False
 
-        obs.obs_source_update(crop, s)
+        obs.obs_source_update(crop, crop_settings)
 
-        obs.obs_data_release(s)
+        obs.obs_data_release(crop_settings)
         obs.obs_source_release(source)
         obs.obs_source_release(crop)
         if (inOut == 0) and (self.zo_timer >= totalFrames):

--- a/zoom_and_follow_mouse.py
+++ b/zoom_and_follow_mouse.py
@@ -205,6 +205,8 @@ class CursorWindow:
         capture for Windows and Linux. In Windows, application data is
         stored as "Title:WindowClass:Executable"
         """
+        global new_source
+
         try:
             # Assuming the OBS data is formatted correctly, we should
             # be able to identify the window

--- a/zoom_and_follow_mouse.py
+++ b/zoom_and_follow_mouse.py
@@ -482,6 +482,26 @@ class CursorWindow:
         elif self.zoom_y_target > y_max:
             self.zoom_y_target = y_max
 
+    def center_on_cursor(self):
+        """
+        Instantly sets the zoom window target location to have the cursor at its
+        center. If completely zoomed out (not interpolating) also sets the
+        current location, so there's no visible travel from where the previous
+        known location was when zooming in again.
+        """
+        mousePos = get_cursor_position()
+        self.zoom_x_target = mousePos.x - self.zoom_w * 0.5
+        self.zoom_y_target = mousePos.y - self.zoom_h * 0.5
+        # Clamp to a valid location inside the source limits
+        self.check_pos()
+
+        # Are we fully zoomed out?
+        if self.zi_timer == 0:
+            # Synchronize the current crop zoom location
+            self.zoom_x = self.zoom_x_target
+            self.zoom_y = self.zoom_y_target
+            print("Skip to cursor location")
+
     def obs_set_crop_settings(self, left, top, width, height):
         """
         Interfaces with OBS to set dimensions of the crop filter used for
@@ -885,14 +905,14 @@ def toggle_zoom(pressed):
             zoom.update_sources()
         if zoom.source_name != "" and not zoom.lock:
             zoom.update_source_size()
+            zoom.center_on_cursor()
             zoom.lock = True
             zoom.tick_enable()
+            print(f"Mouse position: {get_cursor_position()}")
         elif zoom.lock:
             zoom.lock = False
-            zoom.tick_enable()
+            zoom.tick_enable()  # For the zoom out transition
         print(f"Zoom: {zoom.lock}")
-        if zoom.lock:
-            print(f"Mouse position: {get_cursor_position()}")
 
 
 def toggle_follow(pressed):

--- a/zoom_and_follow_mouse.py
+++ b/zoom_and_follow_mouse.py
@@ -19,8 +19,15 @@ description = (
     "calculated as percent of smallest dimension. "
     + "Border of 50% keeps mouse locked in the center of the zoom"
     " frame\n\n"
+    + "Manual Monitor Dimensions constrain the zoom to just the area in the"
+    " defined size. Useful for only zooming in a smaller area in ultrawide"
+    " monitors, for instance.\n\n"
+    + "Manual Offset will move, relative to the top left of the monitor/source,"
+    " the constrained zoom area. In the ultrawide monitor example, this can be"
+    " used to offset the constrained area to be at the right of the screen,"
+    " preventing the zoom from following the cursor to the left side.\n\n"
     + "By tryptech (@yo_tryptech / tryptech#1112)\n\n"
-    + "v.2023.02.13"
+    + "v.2023.03.04"
 )
 
 
@@ -834,7 +841,7 @@ def script_properties():
     obs.obs_properties_add_int(props,
                                "Speed", "Max Scroll Speed", 0, 540, 10)
     obs.obs_properties_add_float_slider(props,
-                                        "Smooth", "Smooth", 0, 10, 1.00)
+                                        "Smooth", "Smooth", 0, 10, 0.1)
     obs.obs_properties_add_int_slider(props,
                                       "Zoom", "Zoom Duration (ms)", 0, 1000, 1)
 

--- a/zoom_and_follow_mouse.py
+++ b/zoom_and_follow_mouse.py
@@ -79,6 +79,7 @@ class CursorWindow:
     # Activate zoom mode?
     lock = False
     track = update = True
+    ticking = False
     zi_timer = zo_timer = 0
     windows = window_titles = monitor = window = window_handle \
         = window_name = ''
@@ -586,13 +587,21 @@ class CursorWindow:
         # and not following the cursor
         if ((not self.lock) and (self.zo_timer >= totalFrames)) \
                 or (self.lock and (not self.track) and (self.zi_timer >= totalFrames)):
-            obs.remove_current_callback()
-            print("Zoom: stop ticking")
+            self.tick_disable()
 
+    def tick_enable(self):
+        if self.ticking:
+            return
 
-    def enable_ticking(self):
         obs.timer_add(self.tick, self.refresh_rate)
-        print("Zoom: start ticking")
+
+        self.ticking = True
+        print(f"Ticking: {self.ticking}")
+
+    def tick_disable(self):
+        obs.remove_current_callback()
+        self.ticking = False
+        print(f"Ticking: {self.ticking}")
 
     def tracking(self):
         """
@@ -888,10 +897,10 @@ def toggle_zoom(pressed):
         if zoom.source_name != "" and not zoom.lock:
             zoom.update_source_size()
             zoom.lock = True
-            zoom.enable_ticking()
+            zoom.tick_enable()
         elif zoom.lock:
             zoom.lock = False
-            zoom.enable_ticking()
+            zoom.tick_enable()
         print(f"Zoom: {zoom.lock}")
         if zoom.lock:
             print(f"Mouse position: {get_cursor_position()}")
@@ -903,6 +912,7 @@ def toggle_follow(pressed):
             zoom.track = False
         elif not zoom.track:
             zoom.track = True
+            # Tick if zoomed in, to enable follow updates
             if zoom.lock:
-                zoom.enable_ticking()
+                zoom.tick_enable()
         print(f"Tracking: {zoom.track}")

--- a/zoom_and_follow_mouse.py
+++ b/zoom_and_follow_mouse.py
@@ -397,11 +397,11 @@ class CursorWindow:
         :return: If the zoom window was moved
         """
 
-        # Don't move zoom window when mouse is outside the source
-        if mousePos.x > (self.source_x + self.source_w) \
-                or mousePos.x < self.source_x \
-                or mousePos.y > (self.source_y + self.source_h) \
-                or mousePos.y < self.source_y:
+        # Don't follow cursor when it is outside the source in both dimensions
+        if (mousePos.x > (self.source_x + self.source_w)
+            or mousePos.x < self.source_x) \
+                and (mousePos.y > (self.source_y + self.source_h)
+                     or mousePos.y < self.source_y):
             return False
 
         # Get active zone edges relative to the source

--- a/zoom_and_follow_mouse.py
+++ b/zoom_and_follow_mouse.py
@@ -343,18 +343,6 @@ class CursorWindow:
                 self.source_x += self.source_x_override
                 self.source_y += self.source_y_override
 
-    def resetZI(self):
-        """
-        Reset the zoom-in timer
-        """
-        self.zi_timer = 0
-
-    def resetZO(self):
-        """
-        Reset the zoom-out timer
-        """
-        self.zo_timer = 0
-
     def cubic_in_out(self, p):
         """
         Cubic in/out easing function. Accelerates until halfway, then
@@ -528,9 +516,10 @@ class CursorWindow:
 
         if not self.lock:
             # Zooming out
-            self.resetZI()
             if self.zo_timer < totalFrames:
                 self.zo_timer += 1
+                # Zoom in will start from same animation position
+                self.zi_timer = totalFrames - self.zo_timer
                 time = self.cubic_in_out(self.zo_timer / totalFrames)
                 obs_set_int(crop_settings, "left", int(((1 - time) * self.zoom_x)))
                 obs_set_int(crop_settings, "top", int(((1 - time) * self.zoom_y)))
@@ -553,9 +542,10 @@ class CursorWindow:
                 self.update = False
         else:
             # Zooming in
-            self.resetZO()
             if self.zi_timer < totalFrames:
                 self.zi_timer += 1
+                # Zoom out will start from same animation position
+                self.zo_timer = totalFrames - self.zi_timer
                 time = self.cubic_in_out(self.zi_timer / totalFrames)
                 obs_set_int(crop_settings, "left", int(time * self.zoom_x))
                 obs_set_int(crop_settings, "top", int(time * self.zoom_y))

--- a/zoom_and_follow_mouse.py
+++ b/zoom_and_follow_mouse.py
@@ -696,8 +696,9 @@ def script_update(settings):
         if len(sources) == 0:
             print("No sources, likely OBS startup.")
     else:
+        print("Non-initial update")
         zoom.update_source_size()
-        print("Source Name: " + zoom.source_name)
+    print("Source Name: " + zoom.source_name)
 
     zoom.zoom_w = obs.obs_data_get_int(settings, "Width")
     zoom.zoom_h = obs.obs_data_get_int(settings, "Height")

--- a/zoom_and_follow_mouse.py
+++ b/zoom_and_follow_mouse.py
@@ -24,7 +24,7 @@ description = (
 )
 
 c = pwc.getMousePos
-def get_position(): return [c().x, c().y]
+def get_cursor_position(): return [c().x, c().y]
 
 
 zoom_id_tog = None
@@ -588,7 +588,7 @@ class CursorWindow:
         """
         if self.lock:
             if self.track or self.update:
-                self.follow(get_position())
+                self.follow(get_cursor_position())
         self.set_crop(int(self.lock))
 
     def tick(self):
@@ -883,7 +883,7 @@ def toggle_zoom(pressed):
             zoom.lock = False
         print(f"Zoom: {zoom.lock}")
         if zoom.lock:
-            print(f"Mouse position: {get_position()}")
+            print(f"Mouse position: {get_cursor_position()}")
 
 
 def toggle_follow(pressed):

--- a/zoom_and_follow_mouse.py
+++ b/zoom_and_follow_mouse.py
@@ -76,7 +76,9 @@ SOURCES = CaptureSources(
 
 
 class CursorWindow:
-    flag = lock = track = update = True
+    # Activate zoom mode?
+    lock = False
+    track = update = True
     zi_timer = zo_timer = 0
     windows = window_titles = monitor = window = window_handle \
         = window_name = ''
@@ -873,13 +875,11 @@ def toggle_zoom(pressed):
     if pressed:
         if new_source:
             zoom.update_sources()
-        if zoom.source_name != "" and zoom.flag:
+        if zoom.source_name != "" and not zoom.lock:
             zoom.update_source_size()
             obs.timer_add(zoom.tick, zoom.refresh_rate)
             zoom.lock = True
-            zoom.flag = False
-        elif not zoom.flag:
-            zoom.flag = True
+        elif zoom.lock:
             zoom.lock = False
         print(f"Zoom: {zoom.lock}")
         if zoom.lock:

--- a/zoom_and_follow_mouse.py
+++ b/zoom_and_follow_mouse.py
@@ -844,8 +844,8 @@ def script_properties():
     obs.obs_property_set_visible(monitor_override, mon_show)
     obs.obs_property_set_visible(m, zoom.monitor_override)
     obs.obs_property_set_visible(rm, zoom.monitor_override)
-    obs.obs_property_set_visible(mon_h, zoom.monitor_override)
-    obs.obs_property_set_visible(mon_w, zoom.monitor_override)
+    obs.obs_property_set_visible(mon_h, zoom.monitor_size_override)
+    obs.obs_property_set_visible(mon_w, zoom.monitor_size_override)
     obs.obs_property_set_visible(mx, zoom.manual_offset)
     obs.obs_property_set_visible(my, zoom.manual_offset)
 

--- a/zoom_and_follow_mouse.py
+++ b/zoom_and_follow_mouse.py
@@ -695,8 +695,9 @@ def script_update(settings):
         sources = obs.obs_enum_sources()
         if len(sources) == 0:
             print("No sources, likely OBS startup.")
-    zoom.update_source_size()
-    print("Source Name: " + zoom.source_name)
+    else:
+        zoom.update_source_size()
+        print("Source Name: " + zoom.source_name)
 
     zoom.zoom_w = obs.obs_data_get_int(settings, "Width")
     zoom.zoom_h = obs.obs_data_get_int(settings, "Height")

--- a/zoom_and_follow_mouse.py
+++ b/zoom_and_follow_mouse.py
@@ -92,7 +92,7 @@ class CursorWindow:
     monitor_override_id = ''
     source_w = source_h = source_x = source_y = zoom_x = zoom_y \
         = source_x_override = source_y_override = 0
-    refresh_rate = int(obs.obs_get_frame_interval_ns()/1000000)
+    refresh_rate = 16
     source_name = source_type = ''
     zoom_w = 1280
     zoom_h = 720
@@ -565,6 +565,10 @@ class CursorWindow:
     def tick_enable(self):
         if self.ticking:
             return
+
+        # Update refresh rate in case user has changed settings. Otherwise
+        # animations will feel slower/faster
+        self.refresh_rate = int(obs.obs_get_frame_interval_ns() / 1000000)
 
         obs.timer_add(self.tick, self.refresh_rate)
         self.ticking = True


### PR DESCRIPTION
The commits have detailed explanations of the changes and I tried to separate them in granular steps as much as it made sense to. Please let me know if you have any questions.

I use a super ultra wide monitor (32:9) and I record only the right half of it. So I fixed the manual offset and size overrides, together with the clamping logic, to work when zooming in on the right side only.

The other changes are mostly related to performance, code readability, maintainability and more pleasant effects.
On that latter topic:
- zoom in/out animation won't jump to the starting point anymore if quickly toggling zoom. They start from the current zoom level.
- smooth follow now interpolates to the final clamped location, preventing sudden stops when going out of bounds with the cursor.
- zoom in always centers the cursor on the screen as the initial zoom position.

Thank you for this awesome plugin! It saves me a ton of time with editing my tutorial videos.
Cheers,
Rod